### PR TITLE
refactor: remove `CommandType` Enum

### DIFF
--- a/src/main/java/duke/AddDeadlineCommand.java
+++ b/src/main/java/duke/AddDeadlineCommand.java
@@ -15,7 +15,7 @@ public class AddDeadlineCommand extends Command {
      * @param deadline    The end date of the deadline.
      */
     public AddDeadlineCommand(String description, LocalDate deadline) {
-        super(description, CommandType.ADD);
+        super(description);
         this.deadline = deadline;
     }
 

--- a/src/main/java/duke/AddEventCommand.java
+++ b/src/main/java/duke/AddEventCommand.java
@@ -16,7 +16,7 @@ public class AddEventCommand extends Command {
      * @param deadline    The end date of the event.
      */
     public AddEventCommand(String description, LocalDate start, LocalDate deadline) {
-        super(description, CommandType.ADD);
+        super(description);
         this.start = start;
         this.deadline = deadline;
     }

--- a/src/main/java/duke/AddTodoCommand.java
+++ b/src/main/java/duke/AddTodoCommand.java
@@ -10,7 +10,7 @@ public class AddTodoCommand extends Command {
      * @param description The description of the todo task.
      */
     public AddTodoCommand(String description) {
-        super(description, CommandType.ADD);
+        super(description);
     }
 
     /**

--- a/src/main/java/duke/Command.java
+++ b/src/main/java/duke/Command.java
@@ -4,38 +4,16 @@ package duke;
  * Class that represents a command that can be executed.
  */
 public abstract class Command {
-    /**
-     * Enum that represents the type of the command.
-     */
-    enum CommandType {
-        LIST,
-        DELETE,
-        ADD,
-        MARK,
-        FIND
-    }
 
-    private String text;
-    private CommandType type;
+    private final String text;
 
     /**
      * Constructor for the command.
      *
      * @param text The text of the command.
-     * @param type The type of the command.
      */
-    public Command(String text, CommandType type) {
+    public Command(String text) {
         this.text = text;
-        this.type = type;
-    }
-
-    /**
-     * Gets the type of the command.
-     *
-     * @return The type of the command.
-     */
-    public CommandType getType() {
-        return type;
     }
 
     /**
@@ -52,7 +30,7 @@ public abstract class Command {
      *
      * @param state The state of the app.
      * @param ui    The user interface of the app.
-     * @return
+     * @return The text output of the command
      */
     public abstract String execute(State state, Ui ui);
 }

--- a/src/main/java/duke/DeleteCommand.java
+++ b/src/main/java/duke/DeleteCommand.java
@@ -12,7 +12,7 @@ public class DeleteCommand extends Command {
      * @param index The index of the task to be deleted.
      */
     public DeleteCommand(int index) {
-        super("", CommandType.DELETE);
+        super("");
         this.index = index;
     }
 

--- a/src/main/java/duke/FindCommand.java
+++ b/src/main/java/duke/FindCommand.java
@@ -9,7 +9,7 @@ public class FindCommand extends Command{
      * @param text The text of the command.
      */
     public FindCommand(String text) {
-        super(text, CommandType.FIND);
+        super(text);
     }
 
     @Override

--- a/src/main/java/duke/ListCommand.java
+++ b/src/main/java/duke/ListCommand.java
@@ -8,7 +8,7 @@ public class ListCommand extends Command {
      * Constructor for the list command.
      */
     public ListCommand() {
-        super("", null);
+        super("");
     }
 
     /**

--- a/src/main/java/duke/MarkCommand.java
+++ b/src/main/java/duke/MarkCommand.java
@@ -12,7 +12,7 @@ public class MarkCommand extends Command {
      * @param index The index of the task to be marked.
      */
     public MarkCommand(int index) {
-        super("", CommandType.MARK);
+        super("A");
         this.index = index;
     }
 


### PR DESCRIPTION
The `CommandType` Enum was being used to label the nature of commands executed.

However, these enums were not being used anywhere in the code other than to label the command. It remains a persistent issue as after going through many iterations, this enum marking was not being used anywhere in the codebase, which signifies the presence of dead code.

Removing the Enum completely allows us to reduce the codebase size whilst maintaining good meaning within the codebase for other developers.

The whole enum is wiped as it is not necessary to remain in the codebase.